### PR TITLE
Strip redundant tokens with count 1 from start of address

### DIFF
--- a/src/functions/address/build_cleaned_address.cpp
+++ b/src/functions/address/build_cleaned_address.cpp
@@ -1,3 +1,4 @@
+// src/functions/address/build_cleaned_address.cpp
 #include "duckdb.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/function_set.hpp"
@@ -12,6 +13,7 @@
 #include <utility>
 #include <vector>
 #include <memory>
+#include <algorithm>
 
 namespace duckdb {
 
@@ -44,23 +46,38 @@ static inline std::shared_ptr<const ParsedTrie> ResolveTrieFromBlob(CleanAddrLoc
 	return cached;
 }
 
-// build_cleaned_address(tokens, trie, drop_above_count, joiner)
-// Updated semantics:
-//   - Always keep at least the first 3 tokens (from the leaf side). If there are fewer than 3 tokens, keep all.
-//   - For k = 1..n, let cnt_k = CountTail(tail_k) where tail_k = last k tokens (i.e., suffix of length k).
-//   - Find the FIRST k such that cnt_k >= drop_above_count (the first time the suffix meets/exceeds the threshold).
-//       * Normally: keep tokens up to and including the boundary token at index (n - k), and DROP all tokens after it.
-//       * Exception: if cnt_k >= 4 * drop_above_count (a "very high" count), DO NOT include the boundary token
-//         (i.e., keep only tokens strictly before index (n - k)).
-//   - In all cases, enforce the "keep at least 3 tokens" rule on the final result.
-//   - If no such k exists (no suffix meets/exceeds threshold), keep all tokens.
-// Notes:
-//   - If drop_above_count <= 0, the threshold condition is trivially true at k=1; the "very high" check is only
-//     applied when drop_above_count > 0 to avoid degenerate behavior.
-// Null policy (unchanged):
-//   - NULL tokens/trie/threshold -> NULL; empty list -> "".
+/*
+build_cleaned_address(tokens, trie, drop_above_count[, strip_redundant_count_one_tokens])
+
+Changes vs previous version:
+  - The joiner argument has been removed; output is always joined with a single space " ".
+  - New optional boolean argument strip_redundant_count_one_tokens (default FALSE):
+      * Compute suffix counts for each token position j as CountTail(tokens[j..end]).
+      * If the leading run (from the leaf side: tokens[0], tokens[1], ...) has count==1,
+        drop ALL of those except the one closest to the root (i.e., keep only the last in that run).
+        - Example counts: [1,1,1,1,1,10,10,...]  -> drop first 4, keep from index 4 onward.
+        - If all tokens are count==1, keep only the last (root-nearest) token.
+      * After this pre-strip, apply the existing threshold rules and then enforce "keep at least 3 tokens"
+        on the shortened list.
+
+Existing threshold rules (unchanged):
+  - Let cnt_k = CountTail(tail_k) where tail_k is the suffix starting at index k.
+  - Find the FIRST boundary index 'start' such that cnt_start >= drop_above_count.
+      • Normally keep tokens up to and including the boundary token (keep_end = start + 1).
+      • If cnt_start >= 4 * drop_above_count (and drop_above_count > 0), exclude the boundary token
+        (keep_end = start).
+  - Enforce "keep at least 3 tokens (from the leaf side)" after all logic.
+
+Null/edge policy (unchanged from prior):
+  - NULL tokens/trie/threshold -> NULL
+  - Empty token list -> "" (empty string)
+*/
 static void BuildCleanedAddressExec(DataChunk &args, ExpressionState &state, Vector &result) {
-	// args: [0]=LIST<VARCHAR> tokens, [1]=BLOB trie, [2]=INTEGER drop_above_count, [3]=VARCHAR joiner
+	// args:
+	//   [0] = LIST<VARCHAR> tokens
+	//   [1] = BLOB trie
+	//   [2] = INTEGER drop_above_count
+	//   [3] = (optional) BOOLEAN strip_redundant_count_one_tokens
 	auto &local_state = ExecuteFunctionState::GetFunctionState(state)->Cast<CleanAddrLocalState>();
 
 	// ----- Inputs -----
@@ -87,17 +104,23 @@ static void BuildCleanedAddressExec(DataChunk &args, ExpressionState &state, Vec
 	thr_vec.ToUnifiedFormat(args.size(), thr_uvf);
 	auto thr_vals = UnifiedVectorFormat::GetData<int32_t>(thr_uvf);
 
-	// Joiner
-	Vector &join_vec = args.data[3];
-	UnifiedVectorFormat join_uvf;
-	join_vec.ToUnifiedFormat(args.size(), join_uvf);
-	auto join_vals = UnifiedVectorFormat::GetData<string_t>(join_uvf);
+	// Optional strip flag
+	const bool has_strip_flag = args.ColumnCount() >= 4;
+	UnifiedVectorFormat flag_uvf;
+	const bool *flag_vals = nullptr;
+	if (has_strip_flag) {
+		Vector &flag_vec = args.data[3];
+		flag_vec.ToUnifiedFormat(args.size(), flag_uvf);
+		flag_vals = UnifiedVectorFormat::GetData<bool>(flag_uvf);
+	}
 
 	auto out = FlatVector::GetData<string_t>(result);
 
 	// Scratch buffers reused across rows
 	std::vector<std::string> toks;     // valid tokens in order
-	std::vector<std::string> tail_rev; // reversed suffix for CountTail
+	std::vector<std::string> rev_toks; // reversed tokens (rightmost first)
+	std::vector<uint32_t> counts;      // counts per token position (for suffix at that index)
+	std::vector<std::string> tail_rev; // reversed suffix for CountTail during threshold step
 
 	for (idx_t i = 0; i < args.size(); ++i) {
 		const auto rid = list_uvf.sel->get_index(i);
@@ -126,13 +149,13 @@ static void BuildCleanedAddressExec(DataChunk &args, ExpressionState &state, Vec
 			threshold = 0; // clamp
 		}
 
-		// Joiner: if NULL, treat as single space (typical)
-		std::string joiner_str;
-		const auto jid = join_uvf.sel->get_index(i);
-		if (join_uvf.validity.RowIsValid(jid)) {
-			joiner_str = join_vals[jid].GetString();
-		} else {
-			joiner_str = " ";
+		// Optional flag: default FALSE
+		bool strip_redundant = false;
+		if (has_strip_flag) {
+			const auto fid = flag_uvf.sel->get_index(i);
+			if (flag_uvf.validity.RowIsValid(fid)) {
+				strip_redundant = flag_vals[fid];
+			}
 		}
 
 		std::shared_ptr<const ParsedTrie> trie_ptr = ResolveTrieFromBlob(local_state, trie_vals[trid]);
@@ -155,38 +178,113 @@ static void BuildCleanedAddressExec(DataChunk &args, ExpressionState &state, Vec
 		}
 
 		// Empty list -> empty string
-		const idx_t n = static_cast<idx_t>(toks.size());
-		if (n == 0) {
+		if (toks.empty()) {
 			out[i] = StringVector::AddString(result, "");
 			continue;
 		}
 
-		// Determine how many tokens to keep using the new rules
+		// ---------------------------------------------------------------------
+		// Precompute suffix counts per token position (single pass along path)
+		// counts[j] = CountTail(tokens[j..end])
+		// ---------------------------------------------------------------------
+		const idx_t n = static_cast<idx_t>(toks.size());
+		rev_toks.clear();
+		rev_toks.reserve(n);
+		for (idx_t k = 0; k < n; ++k) {
+			rev_toks.emplace_back(toks[n - 1 - k]);
+		}
+
+		counts.assign(n, 0);
+		{
+			const PNode *node = trie_ptr->root;
+			bool path_broken = false;
+			for (idx_t t = 0; t < n; ++t) {
+				if (path_broken || !node) {
+					break;
+				}
+				const auto &kids = node->kids;
+				const std::string &tok = rev_toks[t];
+
+				// binary search in sorted children
+				size_t lo = 0, hi = kids.size();
+				bool found = false;
+				while (lo < hi) {
+					size_t mid = (lo + hi) / 2;
+					int cmp = tok.compare(kids[mid].first);
+					if (cmp == 0) {
+						node = kids[mid].second;
+						found = true;
+						break;
+					}
+					if (cmp < 0) {
+						hi = mid;
+					} else {
+						lo = mid + 1;
+					}
+				}
+				if (!found) {
+					path_broken = true;
+					break;
+				}
+				const idx_t idx = n - 1 - t; // forward index
+				counts[idx] = node->cnt;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// (NEW) Optional pre-strip of leading count==1 tokens
+		// Keep only the last token in the leading run of 1's (closest to root).
+		// If no leading 1's or only one, do nothing. If all are 1, keep last.
+		// ---------------------------------------------------------------------
+		idx_t start_idx = 0;
+		if (strip_redundant) {
+			idx_t lead_ones = 0;
+			while (lead_ones < n && counts[lead_ones] == 1) {
+				lead_ones++;
+			}
+			if (lead_ones >= 2) {
+				start_idx = lead_ones - 1; // keep the last '1' in the leading run
+			} else if (lead_ones == n) {
+				// all ones -> keep only the last
+				start_idx = n - 1;
+			}
+		}
+
+		// Build working token view after pre-strip
+		std::vector<std::string> work_toks;
+		work_toks.assign(toks.begin() + start_idx, toks.end());
+		const idx_t wn = static_cast<idx_t>(work_toks.size());
+
+		// If nothing left (paranoia), produce empty string
+		if (wn == 0) {
+			out[i] = StringVector::AddString(result, "");
+			continue;
+		}
+
+		// ---------------------------------------------------------------------
+		// Threshold logic (unchanged), now applied to work_toks
+		// ---------------------------------------------------------------------
 		// Minimum tokens to keep regardless of threshold logic
-		const idx_t min_keep = n < 3 ? n : static_cast<idx_t>(3);
+		const idx_t min_keep = wn < 3 ? wn : static_cast<idx_t>(3);
 
-		idx_t keep_end = n; // default: keep all tokens
-		bool found = false;
-		bool hit = false;
+		idx_t keep_end = wn; // default: keep all tokens
 
-		// Walk from LEAF outward: check prefix tails toks[0..k-1]
-
-		for (idx_t start = 0; start < n; ++start) {
-			// tail = toks[start..n-1]  (build reversed order for CountTail)
+		// Walk from LEAF outward: check suffixes work_toks[start..wn-1]
+		for (idx_t start = 0; start < wn; ++start) {
+			// Build reversed tail for CountTail once per candidate start
 			tail_rev.clear();
-			tail_rev.reserve(n - start);
-			for (idx_t t = n; t-- > start;) { // t = n-1, n-2, ..., start
-				tail_rev.emplace_back(toks[t]);
+			tail_rev.reserve(wn - start);
+			for (idx_t t = wn; t-- > start;) { // t = wn-1, wn-2, ..., start
+				tail_rev.emplace_back(work_toks[t]);
 			}
 
 			const uint32_t cnt = CountTail(*trie_ptr, tail_rev);
 			if (static_cast<int64_t>(cnt) >= static_cast<int64_t>(threshold)) {
-				const idx_t boundary_idx = start; // the FIRST token whose suffix meets threshold
 				const bool very_high =
 				    (threshold > 0) && (static_cast<uint64_t>(cnt) >= static_cast<uint64_t>(threshold) * 4ULL);
 
 				// Normally include boundary; if very high, exclude it
-				idx_t candidate_keep_end = very_high ? boundary_idx : (boundary_idx + 1);
+				idx_t candidate_keep_end = very_high ? start : (start + 1);
 
 				// Enforce "always keep at least 3 tokens (from the leaf)"
 				if (candidate_keep_end < min_keep) {
@@ -194,32 +292,33 @@ static void BuildCleanedAddressExec(DataChunk &args, ExpressionState &state, Vec
 				}
 
 				keep_end = candidate_keep_end;
-				hit = true;
 				break; // stop at the FIRST token above threshold
 			}
 		}
 
-		if (!hit && keep_end < min_keep) {
+		// If no boundary hit and keep_end < min_keep (shouldn't happen), enforce min_keep
+		if (keep_end < min_keep) {
 			keep_end = min_keep;
 		}
 
+		// ---------------------------------------------------------------------
+		// Join the first keep_end tokens with a single space
+		// ---------------------------------------------------------------------
 		size_t total_len = 0;
-		if (keep_end > 0) {
-			for (idx_t j = 0; j < keep_end; ++j) {
-				total_len += toks[j].size();
-			}
-			if (keep_end >= 2) {
-				total_len += (keep_end - 1) * joiner_str.size();
-			}
+		for (idx_t j = 0; j < keep_end; ++j) {
+			total_len += work_toks[j].size();
+		}
+		if (keep_end >= 2) {
+			total_len += (keep_end - 1); // one space between tokens
 		}
 
 		std::string out_str;
 		out_str.reserve(total_len);
 		for (idx_t j = 0; j < keep_end; ++j) {
 			if (j > 0) {
-				out_str += joiner_str;
+				out_str.push_back(' ');
 			}
-			out_str += toks[j];
+			out_str += work_toks[j];
 		}
 
 		out[i] = StringVector::AddString(result, out_str);
@@ -230,18 +329,21 @@ ScalarFunctionSet GetBuildCleanedAddressFunctionSet() {
 	ScalarFunctionSet set("build_cleaned_address");
 
 	const LogicalType tokens_type = LogicalType::LIST(LogicalType::VARCHAR);
-	// Keep the 4-arg form you’re using: (tokens, trie, drop_above_count, joiner)
-	ScalarFunction f({tokens_type, LogicalType::BLOB, LogicalType::INTEGER, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                 BuildCleanedAddressExec);
-	f.init_local_state = CleanAddrInitLocalState;
-	set.AddFunction(f);
 
-	// Optional convenience: 3-arg form with default joiner = ' '
+	// 3-arg form: (tokens, trie, drop_above_count)
 	{
-		ScalarFunction f3({tokens_type, LogicalType::BLOB, LogicalType::INTEGER}, LogicalType::VARCHAR,
-		                  BuildCleanedAddressExec);
-		f3.init_local_state = CleanAddrInitLocalState;
-		set.AddFunction(f3);
+		ScalarFunction f({tokens_type, LogicalType::BLOB, LogicalType::INTEGER}, LogicalType::VARCHAR,
+		                 BuildCleanedAddressExec);
+		f.init_local_state = CleanAddrInitLocalState;
+		set.AddFunction(f);
+	}
+
+	// 4-arg form: (tokens, trie, drop_above_count, strip_redundant_count_one_tokens)
+	{
+		ScalarFunction f4({tokens_type, LogicalType::BLOB, LogicalType::INTEGER, LogicalType::BOOLEAN},
+		                  LogicalType::VARCHAR, BuildCleanedAddressExec);
+		f4.init_local_state = CleanAddrInitLocalState;
+		set.AddFunction(f4);
 	}
 
 	return set;


### PR DESCRIPTION
Idea here is we can clean up business names with a new rule 'strip_redundant_count_one_tokens'


* Add a new optional boolean argument `strip_redundant_count_one_tokens` (default `FALSE`) **as a 5th parameter** to `build_cleaned_address(tokens, trie, drop_above_count, joiner, strip_redundant_count_one_tokens)`.
  (The existing 3-arg and 4-arg forms keep working unchanged.)

* When `strip_redundant_count_one_tokens = TRUE`:

  1. Compute suffix counts for each token along the input path (same single-pass method used in `format_address_with_counts`).
  2. If the **leading** run of tokens (from the leaf side) has count = 1, drop **all** of those except the one **closest to the root** (i.e., keep only the last token in that run).

     * Example: counts `[1,1,1,1,1,10,10,10,10]` → drop the first 4, keep from the 5th (`9`) onward.
     * If **all** tokens have count = 1, keep only the last (root-nearest) token for this step.
  3. After that pre-strip, continue with the existing threshold logic (`drop_above_count`) **on the shortened token list**.
  4. Enforce the “keep at least 3 tokens (from the leaf side)” rule **after** the stripping step (i.e., on the shortened list).

     * That’s why your example `MY LONG BUSINESS NAME 9 LOVE LANE KINGS LANGLEY` becomes `9 LOVE LANE`.

* Everything else (very-high threshold rule = “≥ 4× drop\_above\_count” excludes the boundary token) stays exactly as-is.

If that matches your intent, I’ll go ahead and wire it in with a 5-arg variant and keep the current 3- and 4-arg signatures intact.


This doesn't work at the moment because if you have a 'messy address' and a 'canonical address' like 
MY LONG BUSINESS NAME 1 LOVE LANE KINGS LANGLEY

Then the counts of MY LONG BUSINESS NAME 1 are 2.

Solutions:
-  The trie holds total count AND canonical count (probably best, distinguishing between the two seems important), which would require it to 'know about' the input datasets


Note that we can only do stripping like this for addresses with decent 'support' in the tree/. Suppose we have a unique address, then the whole thing would get stripeed.

Another solution would be to build the trie ONLY from the canonical. 

I don't think any of the existing rules require that the address is definitely in the trie, and the rules should only really apply if we can find the messy address in the canonical?